### PR TITLE
Bugfix/clear screen jarring

### DIFF
--- a/game/console_printer.py
+++ b/game/console_printer.py
@@ -2,25 +2,63 @@ import os
 
 
 class ConsolePrinter():
+    
+    ansi_start = "\033["
+    ansi_end = "\033[0m"
+    previous_screen = []
+
+
+    def __init__(self):
+        self.previous_screen = self.get_empty_screen()
+
+
+    def get_empty_screen(self):
+        terminal_size = os.get_terminal_size()
+        screen = []
+        for line_number in range(0, terminal_size.lines):
+            line = []
+            for column_number in range(0, terminal_size.columns):
+                line.append(' ')
+            screen.append(line)
+        return screen
 
 
     def clear_screen(self):
-        # shift everything up
-        print('\033[2J')
         terminal_size = os.get_terminal_size()
         # print a space on every character of the terminal
         for line in range(0, terminal_size.lines):
             line_str = ''
             for column in range(0, terminal_size.columns):
                 line_str += ' '
-            print(line_str)
+            print(f"{self.ansi_start}{column+1};0H{line_str}{self.ansi_end}")
 
 
     # TODO: colors not working yet
     def char_at(self, x, y, char, color='white'):
         _x = str(x)
         _y = str(y)
-        ansi_start = "\033["
-        ansi_end = "\033[0m"
         position = f"{y+1};{_x}H"
-        print(f"{ansi_start}{position}{char}{ansi_end}")
+        print(f"{self.ansi_start}{position}{char}{self.ansi_end}")
+
+    
+    def draw_screen(self, screen):
+        # Print over the entire screen with what has been stored
+        # in our screen representation.
+        # Only prints over characters that have changed since the last print.
+        lines = len(screen)
+        columns = len(screen[0])
+        for line in range(0, lines):
+            for column in range(0, columns):
+                prev_char = self.previous_screen[line][column]
+                new_char = screen[line][column]
+                if new_char != prev_char:
+                    self.char_at(column, line, new_char)
+
+        # So we don't leave the cursor in an annoying place between draws
+        # we will draw the final character at the bottom right corner
+        bottom_right_char = screen[lines-1][columns-1]
+        self.char_at(columns-1, lines-2, bottom_right_char)
+
+        # Store the current state of the screen so we can
+        # use it again next cycle
+        self.previous_screen = screen

--- a/game/console_printer.py
+++ b/game/console_printer.py
@@ -35,9 +35,7 @@ class ConsolePrinter():
 
     # TODO: colors not working yet
     def char_at(self, x, y, char, color='white'):
-        _x = str(x)
-        _y = str(y)
-        position = f"{y+1};{_x}H"
+        position = f"{y+1};{x}H"
         print(f"{self.ansi_start}{position}{char}{self.ansi_end}")
 
     

--- a/game/console_printer.py
+++ b/game/console_printer.py
@@ -1,5 +1,4 @@
 import os
-import termcolor
 
 
 class ConsolePrinter():
@@ -17,9 +16,11 @@ class ConsolePrinter():
             print(line_str)
 
 
-    # TODO: won't print at the right column, row works though
+    # TODO: colors not working yet
     def char_at(self, x, y, char, color='white'):
         _x = str(x)
         _y = str(y)
-        print(f"\033[{_y};{_x}H")
-        print(f"{termcolor.colored(char, color)}")
+        ansi_start = "\033["
+        ansi_end = "\033[0m"
+        position = f"{y+1};{_x}H"
+        print(f"{ansi_start}{position}{char}{ansi_end}")

--- a/game/console_printer.py
+++ b/game/console_printer.py
@@ -34,7 +34,7 @@ class ConsolePrinter():
 
 
     # TODO: colors not working yet
-    def char_at(self, x, y, char, color='white'):
+    def print_character_at(self, x, y, char, color='white'):
         position = f"{y+1};{x}H"
         print(f"{self.ansi_start}{position}{char}{self.ansi_end}")
 
@@ -50,12 +50,12 @@ class ConsolePrinter():
                 prev_char = self.previous_screen[line][column]
                 new_char = screen[line][column]
                 if new_char != prev_char:
-                    self.char_at(column, line, new_char)
+                    self.print_character_at(column, line, new_char)
 
         # So we don't leave the cursor in an annoying place between draws
         # we will draw the final character at the bottom right corner
         bottom_right_char = screen[lines-1][columns-1]
-        self.char_at(columns-1, lines-2, bottom_right_char)
+        self.print_character_at(columns-1, lines-2, bottom_right_char)
 
         # Store the current state of the screen so we can
         # use it again next cycle

--- a/game/game.py
+++ b/game/game.py
@@ -26,8 +26,18 @@ class Game():
 
     def draw(self):
         self.printer.clear_screen()
-        self.printer.char_at(5, 5, 'W')
-        print('draw')
+        # TODO: don't draw this shape, this is a test
+        shape = [
+            [1, 1, 1, 1, 1,],
+            [1, 0, 0, 0, 1,],
+            [1, 0, 0, 0, 1,],
+            [1, 0, 0, 0, 1,],
+            [1, 1, 1, 1, 1,],
+        ]
+        for row in range(0, len(shape)):
+            for col in range(0, len(shape[row])):
+                if shape[row][col] == 1:
+                    self.printer.char_at(col, row, 'W')
 
 
     def game_loop(self):
@@ -47,3 +57,4 @@ class Game():
     def end_game(self):
         self.input_controller.stop_watching_key_presses()
         self.timer_thread.cancel()
+        self.printer.clear_screen()

--- a/game/game.py
+++ b/game/game.py
@@ -7,7 +7,7 @@ from .console_printer import ConsolePrinter
 class Game():
     game_over = False
     current_speed = 0.5
-    time_between_draws = 0.5
+    time_between_draws = 1 / 30
     printer = None
     input_controller = None
     timer_thread = None

--- a/game/game.py
+++ b/game/game.py
@@ -13,31 +13,52 @@ class Game():
     timer_thread = None
 
 
+    # TODO: delete this
+    character_flipper = False
+    def flip_test_char(self):
+        self.character_flipper = not self.character_flipper
+
+
     def start(self):
         self.printer = ConsolePrinter()
         self.input_controller = InputController(self)
         self.input_controller.start_watching_key_presses()
+        self.printer.clear_screen()
         self.game_loop()
 
 
     def update(self):
-        print('update')
+        pass
 
 
     def draw(self):
-        self.printer.clear_screen()
-        # TODO: don't draw this shape, this is a test
-        shape = [
-            [1, 1, 1, 1, 1,],
-            [1, 0, 0, 0, 1,],
-            [1, 0, 0, 0, 1,],
-            [1, 0, 0, 0, 1,],
-            [1, 1, 1, 1, 1,],
+        # The Strategy:
+        # Every draw cycle will print to every position in the console.
+        # We need to build a 2D array of what should be printed.
+        # So we create a "screen" 2D array that is filled with spaces,
+        # then replace values at certain positions.
+        # Then we only do a print cycle once everything is in place.
+
+        # Create a representation of the screen
+        screen = self.printer.get_empty_screen()
+
+        # TODO: Replace this with real game object data,
+        #       we can logically replace anything we want on the screen
+        #       at this stage
+        ch = 'X' if self.character_flipper else 'O'
+        overrides = [
+            ['press "A" to swap the character'],
+            [' ', '╔', '═','═', '═', '╗',],
+            [' ', '║', ' ', ch, ' ', '║',],
+            [' ', '╚', '═','═', '═', '╝',],
         ]
-        for row in range(0, len(shape)):
-            for col in range(0, len(shape[row])):
-                if shape[row][col] == 1:
-                    self.printer.char_at(col, row, 'W')
+        for line_number in range(0, len(overrides)):
+            line = overrides[line_number]
+            for column_number in range(0, len(line)):
+                override_char = overrides[line_number][column_number]
+                screen[line_number][column_number] = override_char
+
+        self.printer.draw_screen(screen)
 
 
     def game_loop(self):

--- a/game/game.py
+++ b/game/game.py
@@ -7,7 +7,7 @@ from .console_printer import ConsolePrinter
 class Game():
     game_over = False
     current_speed = 0.5
-    time_between_draws = 1 / 30
+    game_loop_speed = 1 / 30
     printer = None
     input_controller = None
     timer_thread = None
@@ -47,7 +47,7 @@ class Game():
         #       at this stage
         ch = 'X' if self.character_flipper else 'O'
         overrides = [
-            ['press "A" to swap the character'],
+            ['press "A" to swap the character, ESC to quit'],
             [' ', '╔', '═','═', '═', '╗',],
             [' ', '║', ' ', ch, ' ', '║',],
             [' ', '╚', '═','═', '═', '╝',],
@@ -71,7 +71,7 @@ class Game():
 
         # wait some time on a separate thread then run game_loop again
         # this avoids using a spin-lock
-        self.timer_thread = threading.Timer(self.time_between_draws, self.game_loop)
+        self.timer_thread = threading.Timer(self.game_loop_speed, self.game_loop)
         self.timer_thread.start()
 
 

--- a/game/input_controller.py
+++ b/game/input_controller.py
@@ -16,6 +16,7 @@ class InputController():
         self.listener = keyboard.Listener(
             on_press=self.on_keydown,
             on_release=self.on_keyup)
+        self.listener.daemon = True
         self.listener.start()
     
 
@@ -24,10 +25,19 @@ class InputController():
 
 
     def on_keydown(self, key):
-        print(key)
         if key == keyboard.Key.esc:
             self.game.end_game()
+            return
+        
+        key_character = None
+        try:
+            key_character = key.char
+        except:
+            pass
+        
+        if key_character == 'a':
+            self.game.flip_test_char()
 
 
     def on_keyup(self, key):
-        print(key)
+        pass


### PR DESCRIPTION
The way we were clearing the screen between every draw was leaving a noticeable empty screen for a split second before drawing again.  This strategy only replaces the characters that changed since the previous draw.  If nothing changed, the draw is skipped, if only 1 character changed, only the one character is updated.